### PR TITLE
correct owner and group can be useful for rootless builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,7 +181,7 @@ jobs:
           cp ../../../assets/images/logo512.png usr/share/icons/hicolor/512x512/apps/io.github.MCDFsteve.FnipaPlay.png
 
           cd ..
-          dpkg-deb --build FnipaPlay-${{ steps.get_version.outputs.version }}-Linux-amd64
+          dpkg-deb --build --root-owner-group FnipaPlay-${{ steps.get_version.outputs.version }}-Linux-amd64
 
       # Upload Artifacts
       - name: Upload Artifacts


### PR DESCRIPTION
如果有另外的发行版需要用容器化重打包这对他们很有用